### PR TITLE
Fix path to run fastapi in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To run the API that the CLI connects to, run:
 
 
 ```
-uv run fastapi dev src/typerdrive-tutorial/api.py
+uv run fastapi dev src/typerdrive_tutorial/api.py
 ```
 
 To run the CLI, run:


### PR DESCRIPTION
The package name in the src is "typerdrive_tutorial" not "typerdrive-tutorial"
![image](https://github.com/user-attachments/assets/f308ea6c-67a7-4cee-a825-d5dcd5852dac)
